### PR TITLE
Dockerfile base image hijack

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Learning a Control for Quadcopter with Reinforcement Learning
 Development environment
 -----------------------
 
+> __WARNING__ The Dockerfile on this project uses a base image which has been hijacked.  
+> The Dockerfile has been modified to comment out the hijacked base.  If you wish to use
+> the base image, please do so with caution.
+
 A docker image is provided for the code development: `brzl/quadcopter:devel`.
 The definition of the image can be found inside the folder `docker`. As you
 can see, it is based on the brezel research platform, with additional python

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,8 @@
-FROM brzl/quadcopter:base
+## WARNING - The base image 'brzl/quadcopter:base' used by this project has been hijacked.  The current base image now conatins malware.
+##           Please use with caution.  If you want to use this base, uncomment the FROM line below.
+##
+## FROM brzl/quadcopter:base
+##
 USER root
 
 # Install extra dependencies


### PR DESCRIPTION
The Dockerfile uses a base image which has been hijacked.  Modified Dockerfile to comment out the FROM line, and added warning.  Updated README to inform users of the Dockerfile problem.